### PR TITLE
Add Ruff CI

### DIFF
--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -23,10 +23,10 @@ jobs:
         run: pip install ruff
 
       - name: Format code
-        run: ruff format .
+        run: ruff --config pyproject.toml format .
 
       - name: Fix lint issues
-        run: ruff check --fix --exit-zero .
+        run: ruff --config pyproject.toml check --fix --exit-zero .
 
       - name: Ensure no remaining lint issues
-        run: ruff check .
+        run: ruff --config pyproject.toml check .

--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -1,0 +1,32 @@
+name: Ruff
+
+on:
+  push:
+    branches: ["master"]
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+
+jobs:
+  lint:
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.draft == false }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+
+      - name: Install Ruff
+        run: pip install ruff
+
+      - name: Format code
+        run: ruff format .
+
+      - name: Fix lint issues
+        run: ruff check --fix --exit-zero .
+
+      - name: Ensure no remaining lint issues
+        run: ruff check .


### PR DESCRIPTION
## Summary
- add CI workflow to run Ruff lint on pull requests and master
- format source before linting
- fail if unfixable lint issues remain

## Testing
- `ruff format --check .`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_686cd3eecd2c832bb60a1791d8495a91